### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     commit-message:
       prefix: "chore"
@@ -25,6 +27,8 @@ updates:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7
   - package-ecosystem: "maven"
     commit-message:
       prefix: "chore"
@@ -39,6 +43,8 @@ updates:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     commit-message:
       prefix: "chore"
@@ -53,3 +59,5 @@ updates:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
